### PR TITLE
Address incompatibility with `heroku-22` stack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -29,7 +29,7 @@ fi
 cache_get_url=$(curl -s https://api.heroku.com/apps/$SHARED_BUILD_CACHE_APP_NAME/build-metadata \
   -H "Accept: application/vnd.heroku+json; version=3.build-metadata" \
   -H "Authorization: Bearer $HEROKU_API_KEY" \
-  | jq '.cache_get_url' | tr -d '"')
+  | jq -r '.cache_get_url')
 
 echo "Restoring shared build cache from app [$SHARED_BUILD_CACHE_APP_NAME]..."
 

--- a/bin/compile
+++ b/bin/compile
@@ -29,7 +29,7 @@ fi
 cache_get_url=$(curl -s https://api.heroku.com/apps/$SHARED_BUILD_CACHE_APP_NAME/build-metadata \
   -H "Accept: application/vnd.heroku+json; version=3.build-metadata" \
   -H "Authorization: Bearer $HEROKU_API_KEY" \
-  | ruby -e "require 'json'; print JSON[STDIN.read]['cache_get_url']")
+  | jq '.cache_get_url' | tr -d '"')
 
 echo "Restoring shared build cache from app [$SHARED_BUILD_CACHE_APP_NAME]..."
 


### PR DESCRIPTION
See https://github.com/Kajabi/heroku-buildpack-shared-build-cache/pull/2 for context.